### PR TITLE
Bump ngspice to ngspice-30-2

### DIFF
--- a/kicad-mac-builder/ngspice.cmake
+++ b/kicad-mac-builder/ngspice.cmake
@@ -4,7 +4,7 @@ ExternalProject_Add(
         ngspice
         PREFIX  ngspice
         GIT_REPOSITORY git://git.code.sf.net/p/ngspice/ngspice
-        GIT_TAG 99a20162d5038a328d335d11da69c9eee0549fdc
+        GIT_TAG ngspice-30-2
         UPDATE_COMMAND      ""
         PATCH_COMMAND       ""
         CONFIGURE_COMMAND  ./autogen.sh


### PR DESCRIPTION
I am not sure where there is a ngspice-30 and ngspice-30-2 tag upstream,
but I guess we should choose the dash two version.