### PR TITLE
5.0.2 rerelease prep

### DIFF
--- a/build.py
+++ b/build.py
@@ -41,6 +41,9 @@ def parse_args(args):
                         help="Build for a release.",
                         action="store_true"
                         )
+    parser.add_argument("--extra-version",
+                        help="Sets the version to the git version, a hyphen, and then this string.",
+                        required=False)
     parser.add_argument("--build-type",
                         help="Build type passed to CMake like Debug, Release, or RelWithDebInfo.  Defaults to Debug, unless --release is set."
                         )
@@ -158,6 +161,8 @@ def build(args):
                      "-DTRANSLATIONS_TAG={}".format(args.translations_ref),
                      "-DKICAD_CMAKE_BUILD_TYPE={}".format(args.build_type),
                      ]
+    if args.extra_version:
+        cmake_command.append("-DKICAD_VERSION_EXTRA={}".format(args.extra_version))
     if args.release_name:
         cmake_command.append("-DRELEASE_NAME={}".format(args.release_name))
     cmake_command.append("../kicad-mac-builder")

--- a/kicad-mac-builder/kicad.cmake
+++ b/kicad-mac-builder/kicad.cmake
@@ -10,7 +10,7 @@ ExternalProject_Add(
         COMMAND                 echo "Making sure we aren't in the middle of a crashed git-am"
         COMMAND                 git am --abort || true
         COMMAND                 git reset --hard ${KICAD_TAG}
-        COMMAND                 ${BIN_DIR}/git-multipatch.sh ${CMAKE_SOURCE_DIR}/patches/kicad/*.patch
+        COMMAND                 ${BIN_DIR}/multipatch.py ${CMAKE_SOURCE_DIR}/patches/kicad/*.patch
         CMAKE_ARGS  ${KICAD_CMAKE_ARGS}
 )
 


### PR DESCRIPTION
Use patch, not git-am to apply kicad patches.  This cleans up the ver…sion info, per Wayne via the mailing list. Add a --extra-version option, passed down to KiCad, so we can re-release versions.  *sigh*