### PR TITLE
Add -L option to curl for docs

### DIFF
--- a/kicad-mac-builder/docs.cmake
+++ b/kicad-mac-builder/docs.cmake
@@ -4,7 +4,7 @@ ExternalProject_Add(
         docs
         PREFIX  docs
         DOWNLOAD_COMMAND mkdir -p ${CMAKE_BINARY_DIR}/docs/src
-        UPDATE_COMMAND curl ${DOCS_TARBALL_URL} -o ${CMAKE_BINARY_DIR}/docs/src/docs.tar.gz
+        UPDATE_COMMAND curl -L ${DOCS_TARBALL_URL} -o ${CMAKE_BINARY_DIR}/docs/src/docs.tar.gz
         CONFIGURE_COMMAND ""
         BUILD_COMMAND tar -xf ${CMAKE_BINARY_DIR}/docs/src/docs.tar.gz -C <INSTALL_DIR> --strip-components=1
         INSTALL_COMMAND ""


### PR DESCRIPTION
This ensures that we can move the URL dor the doc tarball around as we
see fit... Dash big L will make it follow 3XX codes.