### PR TITLE
OCE updates

### DIFF
--- a/ci/src/bootstrap.sh
+++ b/ci/src/bootstrap.sh
@@ -22,5 +22,5 @@ echo "Installing glm 0.9.9.2"
 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/9ce61eaa2776d0ab011e0559a86afff588f6eccb/Formula/glm.rb
 echo "Installing some dependencies"
 brew install swig glew cairo boost doxygen gettext wget bison libtool autoconf automake cmake
-brew install -f /vagrant/external/oce*tar.gz
-
+brew tap brewsci/science
+brew install brewsci/science/oce

--- a/external/README.md
+++ b/external/README.md
@@ -2,3 +2,20 @@ External
 ========
 
 Sometimes wxPython doesn't show up on Sourceforge, so I mirrored the release in this repository.
+
+Generating a new OCE bottle
+---------------------------
+If the OCE bottle no longer works, you can generate a new one.  Setup a system with the oldest version we're supporting.  Install the *full* version of XCode.  It should be the newest that is supported on that OS. For macOS 10.11, this is XCode 8.2.1.  You can do this headlessly, by downloading XCode from the Apple Developer website, extracting it, copying it to /Applications, accepting the license, and then building the bottle.
+
+```
+mkdir xcode
+cd xcode
+xip -x /vagrant/Xcode_8.2.1.xip
+mv Xcode.app /Applications/
+sudo xcodebuild -license accept
+brew tap brewsci/science
+brew install --build-bottle brewsci/science/oce  # this can take a long time!
+brew bottle brewsci/science/oce
+```
+
+Then copy the generated tar.gz into this repository.


### PR DESCRIPTION
The prebuild OCE bottle recently stopped working with homebrew updates.  I documented how to generate new bottles, generated one, but before adding the new one, I want to see if the old issue has been fixed upstream.