### PR TITLE
Move to GitLab URL

### DIFF
--- a/kicad-mac-builder/CMakeLists.txt
+++ b/kicad-mac-builder/CMakeLists.txt
@@ -49,7 +49,7 @@ set( six_DIR ${CMAKE_BINARY_DIR}/six/src/six )
 
 set( ngspice_INSTALL_DIR ${CMAKE_BINARY_DIR}/ngspice-dest )
 
-set( KICAD_URL https://git.launchpad.net/kicad )
+set( KICAD_URL https://gitlab.com/kicad/code/kicad.git )
 set( KICAD_INSTALL_DIR ${CMAKE_BINARY_DIR}/kicad-dest )
 
 # find OCE

--- a/kicad-mac-builder/README.packaging
+++ b/kicad-mac-builder/README.packaging
@@ -46,10 +46,6 @@ Documentation
 =============
 Documentation is available online at http://kicad-pcb.org/help/documentation/.  It is also available inside the various KiCad programs under the Help menu, and after installing from this disk image, is also available at /Library/Application Support/kicad/help.
 
-Changelog
-=========
-You can browse the changelog at https://bazaar.launchpad.net/~kicad-product-committers/kicad/product/changes.
-
 Reporting Issues
 ================
 The KiCad developers work hard to provide quality releases to our users.


### PR DESCRIPTION
The GitLab URL is active now as a mirror of launchpad.  The lead devs
will be moving over to committing only to GitLab soon at which point,
commits will only be visible in the GitLab repository and its mirrors.